### PR TITLE
Use htslib-release bundle instead of direct GIT clone

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -19,12 +19,11 @@ rbcf_version.h:
 
 
 $(HTSDIR)/libhts.so $(HTSDIR)/libhts.a $(HTSLIB)/version.h : $(HTSDIR)/Makefile
-	cd $(HTSDIR) && ./configure && $(MAKE) $(notdir $@)
+	cd $(HTSDIR) && ./configure && sed -i '/^CFLAGS/s/$$/ -fPIC/' Makefile && $(MAKE) $(notdir $@)
 
 	
 $(HTSDIR)/Makefile:
-	test -f $@ || (wget https://github.com/samtools/htslib/releases/download/1.10.2/htslib-1.10.2.tar.bz2 && tar xf htslib-1.10.2.tar.bz2 && mv htslib-1.10.2 htslib)
-	sed -i '/^CFLAGS/s/$$/ -fPIC/' $@
+	test -f $@ || (wget https://github.com/samtools/htslib/releases/download/1.10.2/htslib-1.10.2.tar.bz2 && tar xf htslib-1.10.2.tar.bz2 && mv htslib-1.10.2 $(HTSDIR))
 
 clean:
 	rm -f librbcf.so

--- a/src/Makevars
+++ b/src/Makevars
@@ -19,7 +19,7 @@ rbcf_version.h:
 
 
 $(HTSDIR)/libhts.so $(HTSDIR)/libhts.a $(HTSLIB)/version.h : $(HTSDIR)/Makefile
-	cd $(HTSDIR) && ./configure && sed -i '/^CFLAGS/s/$$/ -fPIC/' Makefile && $(MAKE) $(notdir $@)
+	cd $(HTSDIR) && ./configure && sed -i '/^CFLAGS/s/$$/ -fPIC/' config.mk && $(MAKE) $(notdir $@)
 
 	
 $(HTSDIR)/Makefile:

--- a/src/Makevars
+++ b/src/Makevars
@@ -19,11 +19,11 @@ rbcf_version.h:
 
 
 $(HTSDIR)/libhts.so $(HTSDIR)/libhts.a $(HTSLIB)/version.h : $(HTSDIR)/Makefile
-	cd $(HTSDIR) && $(MAKE) $(notdir $@)
+	cd $(HTSDIR) && ./configure && $(MAKE) $(notdir $@)
 
 	
 $(HTSDIR)/Makefile:
-	test -f $@ || git clone --branch 1.10.2 --depth 1 "https://github.com/samtools/htslib" $(HTSDIR)
+	test -f $@ || (wget https://github.com/samtools/htslib/releases/download/1.10.2/htslib-1.10.2.tar.bz2 && tar xf htslib-1.10.2.tar.bz2 && mv htslib-1.10.2 htslib)
 	sed -i '/^CFLAGS/s/$$/ -fPIC/' $@
 
 clean:


### PR DESCRIPTION
Hi Pierre,
thank you for creating the package - I hope it will prove useful as well ;-)

I had to modify the install script a bit to make it run properly in my conda-based R-environment where I am used dedicated compiler and include directories. 
In such environments, the installation only works if the configure-script is executed which is available in the bundled release.

Best,
Manuel