### PR TITLE
Always build htslib without the libdeflate library

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -28,7 +28,7 @@ $(HTSDIR)/Makefile:
 	wget -O "htslib-$(HSTLIB_VERSION).tar.bz2" "https://github.com/samtools/htslib/releases/download/$(HSTLIB_VERSION)/htslib-$(HSTLIB_VERSION).tar.bz2"
 	tar xfj htslib-$(HSTLIB_VERSION).tar.bz2
 	mv "htslib-$(HSTLIB_VERSION)" "$(HTSDIR)"
-	(cd $(HTSDIR) && ./configure && sed -i '/^CFLAGS/s/$$/ -fPIC/' config.mk) || rm $@
+	(cd $(HTSDIR) && ./configure --without-libdeflate && sed -i '/^CFLAGS/s/$$/ -fPIC/' config.mk) || rm $@
 
 clean:
 	rm -f librbcf.so


### PR DESCRIPTION
If libdeflate is installed on the host, the configure script for htslib will
pick it up and link with it, leading to undefined symbols in the final link
since -ldeflate is missing from PKG_LIBS. We also cannot simply add it to
PKG_LIBS, since then we would get an error on hosts where libdeflate is
unavailable, so just configure htslib without libdeflate support.